### PR TITLE
Added Variadics for Semantic Purposes

### DIFF
--- a/Sources/SwiftUI_CSS/SwiftUI_CSS.swift
+++ b/Sources/SwiftUI_CSS/SwiftUI_CSS.swift
@@ -53,12 +53,22 @@ extension CSSProperty {
     
 }
 
-public struct CSSStyle {
-    
+public struct CSSStyle {    
     fileprivate var properties: [CSSProperty]
+    
+    public init(_ properties: CSSProperty...) {
+        self.properties = properties
+    }
     
     public init(_ properties: [CSSProperty]) {
         self.properties = properties
+    }
+    
+    public init(_ classes: [CSSStyle]) {
+        self.properties = []
+        for classItem in classes {
+            self.properties += classItem.properties
+        }
     }
     
     func applyStyle(content: AnyView) -> AnyView {
@@ -195,12 +205,11 @@ struct CSSStyleModifier: ViewModifier {
 
 
 extension View {
-
-    public func addClassName(_ clsName: CSSStyle) -> some View {
-        ModifiedContent(content: self, modifier: CSSStyleModifier(styleSheet: clsName))
+    public func addClassName(_ clsName: CSSStyle...) -> some View {
+        ModifiedContent(content: self, modifier: CSSStyleModifier(styleSheet: CSSStyle(clsName)))
     }
     
-    public func setStyle(_ properties: [CSSProperty]) -> some View {
+    public func setStyle(_ properties: CSSProperty...) -> some View {
         ModifiedContent(content: self, modifier: CSSStyleModifier(styleSheet: CSSStyle(properties)))
     }
     
@@ -208,5 +217,4 @@ extension View {
         //
         return self
     }
-
 }


### PR DESCRIPTION
Added support for variadics to be able to assign multiple CSSStyles to a view with a single addClassName call. Did the same for CSSStyle to eliminate the requirement for brackets in CSSStyle().

# CSSStyles or "Class Names"

## Before
```Swift
Text("Hello, world!")
  .addClassName(.blue)
  .addClassName(.lines)
  .addClassName(.padLeft)
```

## After
```Swift
Text("Hello, world!")
  .addClassName(.blue, .lines, .padLeft)
```

<hr>

# CSSProperties

## Before
```Swift
Text("The history of languages")
  .setStyle([
    .font(.title),
    .height(responsive.r(40))
])
```

## After
```Swift
Text("The history of languages")
  .setStyle(
    .font(.title),
    .height(responsive.r(40))
)
```
Note the absence of square brackets.

<hr>

I created Unit Tests using the [ViewInspector](https://github.com/nalexn/ViewInspector) framework for SwiftUI and can add those in a separate pull request if there's interest.